### PR TITLE
TGP-1498: add request advice errors

### DIFF
--- a/source/documentation/errors.html.md.erb
+++ b/source/documentation/errors.html.md.erb
@@ -263,6 +263,16 @@ All errors from TGP Digital will return a JSON map with two keys: "code" and "me
     <td>niphlNumber</td>
     <td>Optional field niphlNumber is in the wrong format</td>
   </tr>
+  <tr>
+    <td>1008</td>
+    <td>requestorName</td>
+    <td>Mandatory field requestorName was missing from body or is in the wrong format</td>
+  </tr>
+  <tr>
+    <td>1009</td>
+    <td>requestorEmail</td>
+    <td>Mandatory field requestorEmail was missing from body or is in the wrong format</td>
+  </tr>
 </table>
 
 [REFERENCE_GUIDE_ERRORS]: </api-documentation/docs/reference-guide#errors>


### PR DESCRIPTION
Updated the service guide errors page table to include these additional validation error details:
- requestorName
- requestorEmail